### PR TITLE
System exit code was always 0

### DIFF
--- a/src/org/rascalmpl/shell/ModuleRunner.java
+++ b/src/org/rascalmpl/shell/ModuleRunner.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import org.rascalmpl.value.IValue;
+import org.rascalmpl.value.IInteger;
 import org.rascalmpl.value.io.StandardTextWriter;
 import org.rascalmpl.interpreter.Evaluator;
 
@@ -29,12 +30,12 @@ public class ModuleRunner implements ShellRunner {
 
     IValue v = eval.main(null, module, "main", realArgs);
 
-    if (v != null) {
+    if (v != null && !(v instanceof IInteger)) {
       new StandardTextWriter(true).write(v, eval.getStdOut());
       eval.getStdOut().flush();
     }
 
-    System.exit(0);
+    System.exit(v instanceof IInteger ? ((IInteger) v).intValue() : 0);
     return;
   }
 


### PR DESCRIPTION
#### Description
When running a Rascal module with `main` function, its exit code is always `0`. In addition, the return value of the `main` function is always printed. For instance, if I have `int main(list[str] args) = 1;` it is going to print `1`, but the system exit code remains `0`. This created problems because I missed some failing executions on Travis CI since the exit code was `0`. 

This PR suggestively fixes the problem.

#### Only for integers
I was not sure what the original intention of writing the return value of the main function was, so I left it out and it is going to be skipped only if the return type of the function is integer. 